### PR TITLE
[app][fix] Fix wrong usages of hooks within the Location API implementation

### DIFF
--- a/app/.vscode/settings.json
+++ b/app/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+    "eslint.validate": [
+        "javascript"
+    ]
+}

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,23 +1,25 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { Alert, Platform, SafeAreaView, StatusBar, View } from 'react-native';
+import { Platform, SafeAreaView, StatusBar, View } from 'react-native';
 import RNBootSplash from 'react-native-bootsplash';
 
 import Header from './src/components/Header';
 import HomeScreen from './src/screens/HomeScreen';
 import Background from './src/components/Background';
-import { useLocationPermissions } from './src/hooks/useLocation';
+import { requestLocationPermissions } from './src/services/Location';
 
 const App = () => {
-  const requestedPermissions = useRef(false);
+  const [requestedAuthorization, setRequestedAuthorization] = useState(false);
 
   useEffect(() => {
-    if (!requestedPermissions.current)
-      useLocationPermissions().then(() => {
-        requestedPermissions.current = true;
-        RNBootSplash.hide({ fade: true });
+    if (!requestedAuthorization) {
+      requestLocationPermissions().finally(() => {
+        setRequestedAuthorization(true);
       });
-  }, [requestedPermissions.current]);
+    } else {
+      RNBootSplash.hide({ fade: true });
+    }
+  }, [requestedAuthorization]);
 
   if (Platform.OS === 'android') {
     return (

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useEffect, useMemo, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 import {
   Alert,
   Dimensions,
@@ -8,7 +8,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import { useCurrentLocation, useLocationPermissions } from '../hooks/useLocation';
+import { getCurrentLocation } from '../services/Location';
 import Widget from '../components/Widget';
 
 import type { GeoPosition } from 'react-native-geolocation-service';
@@ -33,12 +33,15 @@ const sentences: Sentence[] = [
 
 const HomeScreen: React.FC<PropsWithChildren<{}>> = () => {
   const screenDimensions = Dimensions.get('screen');
-  const [position, setPosition] = useState({} as GeoPosition);
-  useCurrentLocation((result: GeoPosition) => setPosition(result));
+  const [position, setPosition] = useState<GeoPosition | null>(null);
 
   useEffect(() => {
-    if (Object.keys(position).length > 0)
+    if (position == null) {
+      getCurrentLocation((result: GeoPosition) => setPosition(result));
+    } else {
+      console.log(JSON.stringify(position));
       Alert.alert('Current location:', JSON.stringify(position));
+    }
   }, [position]);
 
   const renderInboxItem = ({ item }: ListRenderItemInfo<Sentence>) => {


### PR DESCRIPTION
### Context:
I was developing without eslint checks, so the Location API was not well implemented with React lifecycle rules.

### Changes
- Now it's according with React lifecycles and ESLint issues were fixed.
- It still has a bug where it does not work on first install. This can be fixed by remodeling the Location API to use hooks (I know, go back to the way it was, but in a better way) or using a database library to query if the device has granted access to location API. This way, once this value is changed, we can retrigger the query for the current location.

### Tests:
- [x] Tested on Android;
- [x] Tested on iOS