### PR TITLE
[server] Add endpoint to sync device token

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
         "axios": "^0.27.2",
+        "class-validator": "^0.13.2",
         "firebase": "^9.9.4",
         "firebase-admin": "^11.1.0",
         "reflect-metadata": "^0.1.13",
@@ -4027,6 +4028,22 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/class-validator": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
+      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
+      "dependencies": {
+        "libphonenumber-js": "^1.9.43",
+        "validator": "^13.7.0"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -7574,6 +7591,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.14",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.14.tgz",
+      "integrity": "sha512-McGS7GV/WjJ2KjfOGhJU1oJn29RYeo7Q+RpANRbUNMQ9gj5XArpbjurSuyYPTejFwbaUojstQ4XyWCrAzGOUXw=="
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -10135,6 +10157,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {
@@ -13614,6 +13644,22 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "optional": true,
+      "peer": true
+    },
+    "class-validator": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
+      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
+      "requires": {
+        "libphonenumber-js": "^1.9.43",
+        "validator": "^13.7.0"
+      }
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -16326,6 +16372,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.10.14",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.14.tgz",
+      "integrity": "sha512-McGS7GV/WjJ2KjfOGhJU1oJn29RYeo7Q+RpANRbUNMQ9gj5XArpbjurSuyYPTejFwbaUojstQ4XyWCrAzGOUXw=="
+    },
     "lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -18223,6 +18274,11 @@
         "@types/istanbul-lib-coverage": "^2.0.1",
         "convert-source-map": "^1.6.0"
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "axios": "^0.27.2",
+    "class-validator": "^0.13.2",
     "firebase": "^9.9.4",
     "firebase-admin": "^11.1.0",
     "reflect-metadata": "^0.1.13",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { DeviceModule } from './device/module';
 import { WeatherModule } from './weather/module';
 
 @Module({
-  imports: [WeatherModule, ConfigModule.forRoot()],
+  imports: [WeatherModule, DeviceModule, ConfigModule.forRoot()],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/server/src/device/controller.ts
+++ b/server/src/device/controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Post, Res, HttpStatus } from '@nestjs/common';
+import { DeviceService } from './service';
+import { SyncDeviceDTO } from './types';
+import { Response } from 'express';
+
+@Controller('device')
+export class DeviceController {
+  constructor(private deviceService: DeviceService) {}
+
+  @Post('/sync')
+  async sync(@Body() body: SyncDeviceDTO, @Res() res: Response) {
+    const syncReponse = await this.deviceService.sync(body);
+
+    if (syncReponse) {
+      res.status(HttpStatus.OK).send();
+    } else {
+      res.status(HttpStatus.INTERNAL_SERVER_ERROR).send();
+    }
+  }
+}

--- a/server/src/device/module.ts
+++ b/server/src/device/module.ts
@@ -1,0 +1,12 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { DeviceController } from './controller';
+import { DeviceService } from './service';
+
+@Module({
+  providers: [DeviceService],
+  controllers: [DeviceController],
+  imports: [ConfigModule.forRoot(), HttpModule],
+})
+export class DeviceModule {}

--- a/server/src/device/service.ts
+++ b/server/src/device/service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { SyncDeviceDTO } from './types';
+import { db } from '../config/firebase';
+
+@Injectable()
+export class DeviceService {
+  async sync(req: SyncDeviceDTO): Promise<boolean> {
+    try {
+      await db.collection('devices').doc(req.token).set(req);
+      return true;
+    } catch (error) {
+      console.log(error);
+      return false;
+    }
+  }
+}

--- a/server/src/device/types.ts
+++ b/server/src/device/types.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty } from 'class-validator';
+
+export interface Location {
+  latitude: number;
+  longitude: number;
+}
+
+export class SyncDeviceDTO {
+  @IsNotEmpty()
+  token: string;
+  @IsNotEmpty()
+  location: Location;
+
+  time?: string; // ISO 8601 format
+}

--- a/server/src/device/types.ts
+++ b/server/src/device/types.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsOptional } from 'class-validator';
 
 export interface Location {
   latitude: number;
@@ -10,6 +10,6 @@ export class SyncDeviceDTO {
   token: string;
   @IsNotEmpty()
   location: Location;
-
+  @IsOptional()
   time?: string; // ISO 8601 format
 }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,8 +1,10 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
### Context
To send push notifications to the users, we need to save their device tokens. The token might refresh from time to time, so a endpoint in the server is necessary to sync the tokens.

### Changes
- Create endpoint to sync tokens. If exists, updates with info, else, creates a new document in `devices/` collection in Cloud Firestore.
- Along with the token, it should be sent the location and time of the notification too.

![Screen Shot 2022-10-17 at 17 11 04](https://user-images.githubusercontent.com/18006523/196273676-e728072d-b22f-43b4-9991-e4ee69ac02eb.png)
![Screen Shot 2022-10-17 at 17 11 52](https://user-images.githubusercontent.com/18006523/196273792-5bb60bc8-cc42-4e1b-aba9-18958bb3b020.png)
